### PR TITLE
Issue #2: Fixing errno issue for python 3.7

### DIFF
--- a/rswt.py
+++ b/rswt.py
@@ -3,7 +3,10 @@
 
 from __future__ import absolute_import, division, print_function
 
-from os import errno
+try:
+    from os import errno
+except ImportError:
+    import errno
 import serial
 import struct
 


### PR DESCRIPTION
Issue #2 

Fix problem where os.errno doesn't exist in 3.7